### PR TITLE
Fix dashboard record wizard types

### DIFF
--- a/app/dashboard/record/new/StepProps.ts
+++ b/app/dashboard/record/new/StepProps.ts
@@ -1,9 +1,12 @@
-// общий контракт для ШАГОВ мастера
+// общий контракт для ВСЕХ шагов мастера
 import type { WizardContext } from './types'
 
-export type StepProps = {
+/** функция перехода к следующему шагу, допускает патч контекста */
+export type OnNext = (patch?: Partial<WizardContext>) => void
+
+export interface StepProps {
   /** накопившийся контекст мастера */
   context: Partial<WizardContext>
   /** патчим контекст и переходим дальше */
-  onNextAction: (patch: Partial<WizardContext>) => void
+  onNextAction: OnNext
 }

--- a/app/dashboard/record/new/steps/StepClient.tsx
+++ b/app/dashboard/record/new/steps/StepClient.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { StepProps } from '../StepProps'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'

--- a/app/dashboard/record/new/steps/StepConfirm.tsx
+++ b/app/dashboard/record/new/steps/StepConfirm.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { StepProps } from '../StepProps'
 
 import { useState } from 'react'
 import { Card } from '@/components/ui/card'
@@ -27,18 +26,19 @@ export default function StepConfirm({ context }: Props) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          clientId:   context.client._id,
-          vehicleId:  context.vehicle._id,
-          serviceIds: context.services.map(s => s._id),
-          slotStart:  context.slot.start,
-          slotEnd:    context.slot.end,
+          clientId:   context.client!._id,
+          vehicleId:  context.vehicle!._id,
+          serviceIds: context.services!.map(s => s._id),
+          slotStart:  context.slot!.start,
+          slotEnd:    context.slot!.end,
         }),
       })
       if (!res.ok) throw new Error(await res.text())
       await res.json()
       router.push('/dashboard/kanban')
-    } catch (err: any) {
-      setError(err.message)
+    } catch (err: unknown) {
+      const e = err as Error
+      setError(e.message)
     } finally {
       setLoading(false)
     }
@@ -49,12 +49,12 @@ export default function StepConfirm({ context }: Props) {
       <h2 className="text-xl font-bold">Подтверждение</h2>
 
       <ul className="text-sm space-y-1">
-        <li><b>Клиент:</b> {context.client.name} ({context.client.phone})</li>
-        <li><b>Авто:</b> {context.vehicle.brand} {context.vehicle.model}</li>
-        <li><b>Услуги:</b> {context.services.map(s => s.name).join(', ')}</li>
+        <li><b>Клиент:</b> {context.client!.name} ({context.client!.phone})</li>
+        <li><b>Авто:</b> {context.vehicle!.brand} {context.vehicle!.model}</li>
+        <li><b>Услуги:</b> {context.services!.map(s => s.name).join(', ')}</li>
         <li>
           <b>Время:</b>{' '}
-          {format(new Date(context.slot.start), 'd MMM yyyy HH:mm', { locale: ru })}
+          {format(new Date(context.slot!.start), 'd MMM yyyy HH:mm', { locale: ru })}
         </li>
       </ul>
 

--- a/app/dashboard/record/new/steps/StepServices.tsx
+++ b/app/dashboard/record/new/steps/StepServices.tsx
@@ -1,16 +1,15 @@
 'use client'
-import type { StepProps } from '../StepProps'
 
 import { useEffect, useState } from 'react'
 import { Card } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Button } from '@/components/ui/button'
 import { Service } from '@/app/dashboard/record/new/types'
-type Props = {
-  onNext: (data: { services: Service[] }) => void
-}
+import type { StepProps } from '../StepProps'
 
-export default function StepServices({ onNext }: Props) {
+type Props = StepProps
+
+export default function StepServices({ onNextAction }: Props) {
   const [services, setServices] = useState<Service[]>([])
   const [selected, setSelected] = useState<Service[]>([])
   const [loading, setLoading] = useState(true)
@@ -36,7 +35,7 @@ export default function StepServices({ onNext }: Props) {
 
   const handleNext = () => {
     if (selected.length === 0) return
-    onNext({ services: selected })
+    onNextAction({ services: selected })
   }
 
   return (

--- a/app/dashboard/record/new/steps/StepSlot.tsx
+++ b/app/dashboard/record/new/steps/StepSlot.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { StepProps } from '../StepProps'
 
 import { useEffect, useMemo, useState } from 'react'
 import { format, addMinutes } from 'date-fns'
@@ -8,18 +7,16 @@ import { ru } from 'date-fns/locale'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Service, Slot, WizardContext } from '@/app/dashboard/record/new/types'
+import { Service, Slot } from '@/app/dashboard/record/new/types'
+import type { StepProps } from '../StepProps'
 
-type Props = {
-  context: WizardContext
-  onNext: (data: Partial<WizardContext>) => void
-}
+type Props = StepProps
 
 /** суммируем минуты выбранных услуг */
 const totalDuration = (services: Service[]) =>
   services.reduce((acc, s) => acc + s.duration, 0)
 
-export default function StepSlot({ context, onNext }: Props) {
+export default function StepSlot({ context, onNextAction }: Props) {
   const durationMinutes = totalDuration(context.services ?? [])
   const [date, setDate] = useState<string>(() => format(new Date(), 'yyyy-MM-dd'))
   const [slots, setSlots] = useState<Slot[]>([])
@@ -37,7 +34,7 @@ export default function StepSlot({ context, onNext }: Props) {
 
   /** при выборе */
   const choose = (slot: Slot) => setSelected(slot)
-  const next = () => selected && onNext({ slot: selected })
+  const next = () => selected && onNextAction({ slot: selected })
 
   /* человекочитаемый заголовок */
   const headerDate = useMemo(() => {

--- a/app/dashboard/record/new/steps/StepVehicle.tsx
+++ b/app/dashboard/record/new/steps/StepVehicle.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { StepProps } from '../StepProps'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'


### PR DESCRIPTION
## Summary
- define `OnNext` in StepProps
- ensure confirm step uses non-null assertions and typed error
- make services and slot steps reuse StepProps
- remove unused imports across wizard steps

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6856d8d77e5883228288d05ccb942e97