### PR TITLE
Implement core API routes and fix vehicle step

### DIFF
--- a/app/api/slots/route.ts
+++ b/app/api/slots/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { dbConnect } from '@/lib/db'
+import { User } from '@/models/User'
+import { Visit } from '@/models/Visit'
+import { addMinutes } from 'date-fns'
+
+export async function GET(req: NextRequest) {
+  const dateStr = req.nextUrl.searchParams.get('date')
+  const duration = parseInt(req.nextUrl.searchParams.get('duration') || '0')
+  if (!dateStr || !duration) {
+    return new NextResponse('Bad request', { status: 400 })
+  }
+
+  await dbConnect()
+  const mechanics = await User.find({ role: 'mechanic' })
+  const dayStart = new Date(`${dateStr}T00:00:00`)
+  const dayEnd = new Date(`${dateStr}T23:59:59`)
+  const visits = await Visit.find({
+    slotStart: { $gte: dayStart, $lte: dayEnd }
+  })
+
+  const slots: Array<{
+    start: string
+    end: string
+    mechanicId: string
+    mechanicName: string
+  }> = []
+
+  const openHour = 9
+  const closeHour = 18
+  for (const m of mechanics) {
+    for (let hour = openHour; hour <= closeHour - Math.ceil(duration / 60); hour++) {
+      const startDate = new Date(`${dateStr}T${hour.toString().padStart(2,'0')}:00:00`)
+      const endDate = addMinutes(startDate, duration)
+      const overlap = visits.some(v => String(v.mechanicId) === String(m._id) &&
+        !(endDate <= v.slotStart || startDate >= v.slotEnd))
+      if (!overlap && endDate.getHours() <= closeHour) {
+        slots.push({
+          start: startDate.toISOString(),
+          end: endDate.toISOString(),
+          mechanicId: m._id.toString(),
+          mechanicName: m.email
+        })
+      }
+    }
+  }
+
+  return NextResponse.json(slots)
+}

--- a/app/api/vehicles/route.ts
+++ b/app/api/vehicles/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { dbConnect } from '@/lib/db'
+import { Client } from '@/models/Client'
+
+export async function GET(req: NextRequest) {
+  const clientId = req.nextUrl.searchParams.get('clientId')
+  if (!clientId) return new NextResponse('Missing clientId', { status: 400 })
+  await dbConnect()
+  const client = await Client.findById(clientId)
+  return NextResponse.json(client?.vehicles ?? [])
+}
+
+export async function POST(req: NextRequest) {
+  const { clientId, ...data } = await req.json()
+  if (!clientId) return new NextResponse('Missing clientId', { status: 400 })
+  await dbConnect()
+  const client = await Client.findById(clientId)
+  if (!client) return new NextResponse('Client not found', { status: 404 })
+  client.vehicles.push(data)
+  await client.save()
+  const vehicle = client.vehicles.at(-1)
+  return NextResponse.json(vehicle, { status: 201 })
+}

--- a/app/api/visits/route.ts
+++ b/app/api/visits/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { dbConnect } from '@/lib/db'
+import { Visit } from '@/models/Visit'
+
+export async function POST(req: NextRequest) {
+  const data = await req.json()
+  await dbConnect()
+  const visit = await Visit.create(data)
+  return NextResponse.json(visit, { status: 201 })
+}

--- a/app/dashboard/record/new/steps/StepConfirm.tsx
+++ b/app/dashboard/record/new/steps/StepConfirm.tsx
@@ -31,6 +31,7 @@ export default function StepConfirm({ context }: Props) {
           serviceIds: context.services!.map(s => s._id),
           slotStart:  context.slot!.start,
           slotEnd:    context.slot!.end,
+          mechanicId: context.slot!.mechanicId,
         }),
       })
       if (!res.ok) throw new Error(await res.text())
@@ -50,8 +51,8 @@ export default function StepConfirm({ context }: Props) {
 
       <ul className="text-sm space-y-1">
         <li><b>Клиент:</b> {context.client!.name} ({context.client!.phone})</li>
-        <li><b>Авто:</b> {context.vehicle!.brand} {context.vehicle!.model}</li>
-        <li><b>Услуги:</b> {context.services!.map(s => s.name).join(', ')}</li>
+        <li><b>Авто:</b> {context.vehicle!.make} {context.vehicle!.model}</li>
+        <li><b>Услуги:</b> {context.services!.map(s => s.title).join(', ')}</li>
         <li>
           <b>Время:</b>{' '}
           {format(new Date(context.slot!.start), 'd MMM yyyy HH:mm', { locale: ru })}

--- a/app/dashboard/record/new/steps/StepServices.tsx
+++ b/app/dashboard/record/new/steps/StepServices.tsx
@@ -51,7 +51,7 @@ export default function StepServices({ onNextAction }: Props) {
               checked={selected.some(s => s._id === service._id)}
               onCheckedChange={() => toggleService(service)}
             />
-            {service.name} ({service.duration} мин)
+            {service.title} ({service.durationMinutes} мин)
           </label>
         ))}
       </div>

--- a/app/dashboard/record/new/steps/StepSlot.tsx
+++ b/app/dashboard/record/new/steps/StepSlot.tsx
@@ -14,7 +14,7 @@ type Props = StepProps
 
 /** суммируем минуты выбранных услуг */
 const totalDuration = (services: Service[]) =>
-  services.reduce((acc, s) => acc + s.duration, 0)
+  services.reduce((acc, s) => acc + s.durationMinutes, 0)
 
 export default function StepSlot({ context, onNextAction }: Props) {
   const durationMinutes = totalDuration(context.services ?? [])

--- a/app/dashboard/record/new/steps/StepVehicle.tsx
+++ b/app/dashboard/record/new/steps/StepVehicle.tsx
@@ -9,9 +9,9 @@ import { Input } from '@/components/ui/input'
 import type { WizardContext, Vehicle } from '@/app/dashboard/record/new/types'
 
 const schema = z.object({
-  brand: z.string().min(2),
+  make: z.string().min(2),
   model: z.string().min(1),
-  plate: z.string().min(5),
+  licensePlate: z.string().min(5),
 })
 type Form = z.infer<typeof schema>
 
@@ -54,7 +54,7 @@ export default function StepVehicle({ context, onNextAction }: Props) {
           <div className="flex flex-col gap-2">
             {vehicles.map(v => (
               <Button key={v._id} variant="outline" onClick={() => select(v)}>
-                {v.brand} {v.model} • {v.plate}
+                {v.make} {v.model} • {v.licensePlate}
               </Button>
             ))}
           </div>
@@ -64,12 +64,12 @@ export default function StepVehicle({ context, onNextAction }: Props) {
 
       <p>Или добавьте новый:</p>
       <form onSubmit={handleSubmit(create)} className="space-y-2">
-        <Input placeholder="Марка" {...register('brand')} />
-        {errors.brand && <small className="text-destructive">{errors.brand.message}</small>}
+        <Input placeholder="Марка" {...register('make')} />
+        {errors.make && <small className="text-destructive">{errors.make.message}</small>}
         <Input placeholder="Модель" {...register('model')} />
         {errors.model && <small className="text-destructive">{errors.model.message}</small>}
-        <Input placeholder="Гос-номер" {...register('plate')} />
-        {errors.plate && <small className="text-destructive">{errors.plate.message}</small>}
+        <Input placeholder="Гос-номер" {...register('licensePlate')} />
+        {errors.licensePlate && <small className="text-destructive">{errors.licensePlate.message}</small>}
         <Button type="submit">Добавить →</Button>
       </form>
     </Card>

--- a/app/dashboard/record/new/types.ts
+++ b/app/dashboard/record/new/types.ts
@@ -11,18 +11,18 @@ export type Client = {
 
 export type Vehicle = {
   _id?: string
-  brand: string
+  make: string
   model: string
-  plate: string
+  licensePlate: string
   vin?: string
   year?: number
 }
 
 export type Service = {
   _id: string
-  name: string
+  title: string
   price: number
-  duration: number
+  durationMinutes: number
 }
 
 export type TimeSlot = {


### PR DESCRIPTION
## Summary
- add missing API routes for vehicles, slots and visits
- fix vehicle step to send proper fields and display fetched data
- update service types and wizard steps to match backend schema
- support mechanic and slot info when creating a visit

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6857791c403c832297d18d7b387fc0e4